### PR TITLE
feat(analytics): GA4 + GTM tracking for formation.cloud

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -161,9 +161,32 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en">
+      <head>
+        {process.env.NEXT_PUBLIC_GTM_ID && (
+          <script
+            dangerouslySetInnerHTML={{
+              __html: `(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+})(window,document,'script','dataLayer','${process.env.NEXT_PUBLIC_GTM_ID}');`,
+            }}
+          />
+        )}
+      </head>
       <body
         className={`${geistSans.variable} ${hauoraSans.variable} ${interDisplay.variable} ${geistMono.variable} antialiased`}
       >
+        {process.env.NEXT_PUBLIC_GTM_ID && (
+          <noscript>
+            <iframe
+              src={`https://www.googletagmanager.com/ns.html?id=${process.env.NEXT_PUBLIC_GTM_ID}`}
+              height="0"
+              width="0"
+              style={{ display: "none", visibility: "hidden" }}
+            />
+          </noscript>
+        )}
         <Providers>
           <ModalProvider>{children}</ModalProvider>
         </Providers>

--- a/app/providers.tsx
+++ b/app/providers.tsx
@@ -6,62 +6,91 @@ import { toast } from "sonner";
 import { getAuthToken } from "@dynamic-labs/sdk-react-core";
 import { AuthProvider } from "@/components/auth-provider";
 import { jwtDecode } from "@/lib/utils";
+import { useEffect, Suspense } from "react";
+import { GTMRouteTracker } from "@/components/GTMRouteTracker";
+import { captureUTM } from "@/lib/utm";
+import { pushDataLayer } from "@/lib/gtm";
+
+function UTMCapture() {
+  useEffect(() => {
+    const utm = captureUTM();
+    if (utm) {
+      pushDataLayer({ event: "utm_captured", ...utm });
+    }
+  }, []);
+  return null;
+}
 
 export function Providers({ children }: { children: React.ReactNode }) {
   return (
-    <DynamicContextProvider
-      settings={{
-        environmentId: process.env.NEXT_PUBLIC_DYNAMIC_ENVIRONMENT_ID!,
-        walletConnectors: [EthereumWalletConnectors],
-        displaySiweStatement: true,
-        appName: "Formation",
-        appLogoUrl: "/logo.png",
-        events: {
-          onAuthSuccess: async ({ user, primaryWallet, handleLogOut }) => {
-            try {
-              console.log("Auth success", user, primaryWallet);
-              const token = getAuthToken();
+    <>
+      <UTMCapture />
+      <Suspense>
+        <GTMRouteTracker />
+      </Suspense>
+      <DynamicContextProvider
+        settings={{
+          environmentId: process.env.NEXT_PUBLIC_DYNAMIC_ENVIRONMENT_ID!,
+          walletConnectors: [EthereumWalletConnectors],
+          displaySiweStatement: true,
+          appName: "Formation",
+          appLogoUrl: "/logo.png",
+          events: {
+            onAuthSuccess: async ({ user, primaryWallet, handleLogOut }) => {
+              try {
+                console.log("Auth success", user, primaryWallet);
+                const token = getAuthToken();
 
-              console.log("Token", token, user);
+                console.log("Token", token, user);
 
-              if (!token) {
-                throw new Error("No authentication token found");
+                if (!token) {
+                  throw new Error("No authentication token found");
+                }
+
+                const response = await fetch("/api/account/create", {
+                  method: "POST",
+                  headers: {
+                    Authorization: `Bearer ${token}`,
+                    "Content-Type": "application/json",
+                  },
+                  body: JSON.stringify({
+                    email: user?.email,
+                    address: primaryWallet?.address,
+                    name: user.firstName || user.lastName || "--",
+                    access_token: token,
+                    refresh_token: token,
+                    dynamic_id: user.userId,
+                    expires_at: 1000000000,
+                    token_type: "Bearer",
+                    scope: "read:user,user:email",
+                  }),
+                });
+
+                if (!response.ok) {
+                  throw new Error("Failed to create account");
+                }
+
+                const { getFirstTouchUTM } = await import("@/lib/utm");
+                pushDataLayer({
+                  event: "sign_in_success",
+                  user_id: user.userId,
+                  auth_method: primaryWallet ? "wallet" : "email",
+                  ...getFirstTouchUTM(),
+                });
+
+                toast.success("Account created successfully!");
+              } catch (error) {
+                console.error("Error creating account:", error);
+                pushDataLayer({ event: "sign_in_error" });
+                toast.error("Failed to create account. Please try again.");
+                handleLogOut();
               }
-
-              const response = await fetch("/api/account/create", {
-                method: "POST",
-                headers: {
-                  Authorization: `Bearer ${token}`,
-                  "Content-Type": "application/json",
-                },
-                body: JSON.stringify({
-                  email: user?.email,
-                  address: primaryWallet?.address,
-                  name: user.firstName || user.lastName || "--",
-                  access_token: token,
-                  refresh_token: token,
-                  dynamic_id: user.userId,
-                  expires_at: 1000000000,
-                  token_type: "Bearer",
-                  scope: "read:user,user:email",
-                }),
-              });
-
-              if (!response.ok) {
-                throw new Error("Failed to create account");
-              }
-
-              toast.success("Account created successfully!");
-            } catch (error) {
-              console.error("Error creating account:", error);
-              toast.error("Failed to create account. Please try again.");
-              handleLogOut();
-            }
+            },
           },
-        },
-      }}
-    >
-      <AuthProvider>{children}</AuthProvider>
-    </DynamicContextProvider>
+        }}
+      >
+        <AuthProvider>{children}</AuthProvider>
+      </DynamicContextProvider>
+    </>
   );
 }

--- a/components/AuthButton.tsx
+++ b/components/AuthButton.tsx
@@ -14,6 +14,7 @@ import { useRouter } from "next/navigation";
 import clsx from "clsx";
 import { useAuth } from "./auth-provider";
 import { getPlanFromPriceId } from "@/lib/stripe";
+import { gtmEvent } from "@/lib/gtm";
 
 export function AuthButton({
   className,
@@ -41,6 +42,7 @@ export function AuthButton({
 
   // Subscribe to auth events
   useDynamicEvents("logout", () => {
+    gtmEvent("sign_out");
     toast.info("Successfully logged out");
   });
 
@@ -50,6 +52,7 @@ export function AuthButton({
 
   // Handle auth failures
   useDynamicEvents("authFailure", () => {
+    gtmEvent("sign_in_error");
     toast.error("Authentication failed");
   });
 
@@ -79,6 +82,7 @@ export function AuthButton({
     if (primaryWallet) {
       router.push("/marketplace/settings");
     } else {
+      gtmEvent("sign_in_flow_opened");
       setShowAuthFlow(true);
     }
   };

--- a/components/GTMRouteTracker.tsx
+++ b/components/GTMRouteTracker.tsx
@@ -1,0 +1,40 @@
+/**
+ * GTM Route Tracker
+ *
+ * SPA-aware route change listener. Pushes page_view events to the GTM
+ * dataLayer on every Next.js App Router client-side navigation.
+ * Must be wrapped in <Suspense> in the parent.
+ *
+ * @purpose Fire page_view on every App Router navigation
+ */
+
+"use client";
+
+import { useEffect, useRef } from "react";
+import { usePathname, useSearchParams } from "next/navigation";
+import { pushDataLayer } from "@/lib/gtm";
+
+export function GTMRouteTracker() {
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+  const isFirstRender = useRef(true);
+
+  useEffect(() => {
+    if (isFirstRender.current) {
+      isFirstRender.current = false;
+      return;
+    }
+
+    const qs = searchParams?.toString();
+    const url = pathname + (qs ? `?${qs}` : "");
+
+    pushDataLayer({
+      event: "page_view",
+      page_path: pathname,
+      page_url: url,
+      page_title: typeof document !== "undefined" ? document.title : "",
+    });
+  }, [pathname, searchParams]);
+
+  return null;
+}

--- a/lib/gtm.ts
+++ b/lib/gtm.ts
@@ -1,0 +1,27 @@
+/**
+ * GTM DataLayer Utility
+ *
+ * Typed helpers for pushing events to the GTM dataLayer.
+ *
+ * @purpose DataLayer push helpers for GTM — single source of truth for all event firing
+ */
+
+declare global {
+  interface Window {
+    dataLayer: Record<string, unknown>[];
+  }
+}
+
+export function pushDataLayer(payload: { event: string; [key: string]: unknown }): void {
+  if (typeof window === "undefined") return;
+  try {
+    window.dataLayer = window.dataLayer || [];
+    window.dataLayer.push(payload);
+  } catch {
+    // Analytics should never break user flows.
+  }
+}
+
+export function gtmEvent(name: string, params?: Record<string, unknown>): void {
+  pushDataLayer({ event: name, ...params });
+}

--- a/lib/utm.ts
+++ b/lib/utm.ts
@@ -1,0 +1,62 @@
+/**
+ * UTM Capture Utility
+ *
+ * Reads UTM parameters from the current URL and persists them.
+ * - First-touch: stored in localStorage, never overwritten
+ * - Session UTM: stored in sessionStorage, updated each visit
+ *
+ * @purpose Capture + persist UTM attribution for acquisition funnel analysis
+ */
+
+const FIRST_TOUCH_KEY = "utm_first_touch";
+const SESSION_KEY = "utm_session";
+
+export interface UTMParams {
+  utm_source?: string;
+  utm_medium?: string;
+  utm_campaign?: string;
+  utm_term?: string;
+  utm_content?: string;
+}
+
+export function captureUTM(): UTMParams | null {
+  if (typeof window === "undefined") return null;
+
+  const params = new URLSearchParams(window.location.search);
+  const utm: UTMParams = {};
+
+  const source = params.get("utm_source");
+  const medium = params.get("utm_medium");
+  const campaign = params.get("utm_campaign");
+  const term = params.get("utm_term");
+  const content = params.get("utm_content");
+
+  if (!source && !medium && !campaign) return null;
+
+  if (source) utm.utm_source = source;
+  if (medium) utm.utm_medium = medium;
+  if (campaign) utm.utm_campaign = campaign;
+  if (term) utm.utm_term = term;
+  if (content) utm.utm_content = content;
+
+  try {
+    sessionStorage.setItem(SESSION_KEY, JSON.stringify(utm));
+    if (!localStorage.getItem(FIRST_TOUCH_KEY)) {
+      localStorage.setItem(FIRST_TOUCH_KEY, JSON.stringify(utm));
+    }
+  } catch {
+    // Storage may be blocked in private browsing.
+  }
+
+  return utm;
+}
+
+export function getFirstTouchUTM(): UTMParams {
+  if (typeof window === "undefined") return {};
+  try {
+    const stored = localStorage.getItem(FIRST_TOUCH_KEY);
+    return stored ? JSON.parse(stored) : {};
+  } catch {
+    return {};
+  }
+}


### PR DESCRIPTION
## Summary

- **`lib/gtm.ts`** — `pushDataLayer()` + `gtmEvent()` helpers, typed `window.dataLayer`
- **`lib/utm.ts`** — First-touch UTM in localStorage (never overwritten) + session UTM in sessionStorage
- **`components/GTMRouteTracker.tsx`** — SPA-aware `page_view` push on every App Router navigation (skips first render, must be in `<Suspense>`)
- **`app/layout.tsx`** — GTM `<script>` injected in `<head>` + `<noscript>` iframe, guarded by `NEXT_PUBLIC_GTM_ID` env var
- **`app/providers.tsx`** — UTM capture on mount, `<Suspense><GTMRouteTracker /></Suspense>`, `sign_in_success` (with `user_id` + first-touch UTM) and `sign_in_error` in Dynamic's `onAuthSuccess`
- **`components/WaitlistDialog.tsx`** — `waitlist_modal_opened`, `waitlist_form_submitted` (with `interests_count`, `company_provided`, `email_domain`), `waitlist_signup_success`, `waitlist_signup_duplicate`
- **`components/AuthButton.tsx`** — `sign_in_flow_opened`, `sign_out`, `sign_in_error`

## Environment variables needed

```
NEXT_PUBLIC_GTM_ID=GTM-XXXXXXX
```

Add to Vercel project settings before deploying.

## Test plan

- [ ] Add `NEXT_PUBLIC_GTM_ID` to Vercel env vars (create new GTM container for formation.cloud)
- [ ] Open GTM Preview mode and visit formation.cloud — verify `page_view` fires on navigation
- [ ] Open the waitlist modal — verify `waitlist_modal_opened` fires
- [ ] Submit the waitlist form — verify `waitlist_form_submitted` and `waitlist_signup_success` fire
- [ ] Click Join/Login button — verify `sign_in_flow_opened` fires
- [ ] Complete auth — verify `sign_in_success` fires with `user_id` and UTM params

🤖 Generated with [Claude Code](https://claude.com/claude-code)